### PR TITLE
Consertando o erro no código na instalação do MongoDB no Ubuntu 15

### DIFF
--- a/pt-br/installation.md~
+++ b/pt-br/installation.md~
@@ -33,7 +33,7 @@ echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.0 multiverse" 
 Ubuntu 15:
 
 ```
-echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list"
 ```
 
 Por fim, rodar o comando:


### PR DESCRIPTION
Não precisa de aspas no final do código, na instação do MongoDB no Ubuntu 15.
