### PR TITLE
Corrige link para o arquivo do exercício

### DIFF
--- a/pt-br/export_import.md
+++ b/pt-br/export_import.md
@@ -37,7 +37,7 @@ Onde:
 
 > Esse exercício se encontra no conteúdo da aula.
 
-Como ainda não temos muitos dados para usarmos o `mongoexport` iremos trabalhar apenas com o `mongoimport` nesse momento. Para fazermos isso primeiramente baixe [esse JSON](https://raw.githubusercontent.com/Webschool-io/be-mean-instagram/master/Apostila/module-mongodb/src/data/restaurantes.json).
+Como ainda não temos muitos dados para usarmos o `mongoexport` iremos trabalhar apenas com o `mongoimport` nesse momento. Para fazermos isso primeiramente baixe [esse JSON](https://raw.githubusercontent.com/Webschool-io/MongoDb-ebook/master/src/data/restaurantes.json).
 
 Após importar ele para uma coleção chamada `restaurantes`, no banco `be-mean`, copie o que foi escrito no seu terminal, por exemplo:
 


### PR DESCRIPTION
O link para o arquivo "restaurantes.json" está quebrado, aponta para um arquivo que não existe no repositório "be-mean-instagram". O novo link aponta para o arquivo "restaurantes.json" existente no repositório "MongoDb-ebook".
